### PR TITLE
fix: remove videre lenker/utforsk videre

### DIFF
--- a/src/components/content/detail/DetailContentDisplay.tsx
+++ b/src/components/content/detail/DetailContentDisplay.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState, type MouseEvent } from 'react'
 import { ChevronRightIcon } from '@navikt/aksel-icons'
 import { Alert, Heading, Paragraph } from '@digdir/designsystemet-react'
+import { useNavigate } from 'react-router-dom'
 import {
   getDetailContentTypeLabel,
   isEhelsestandardContentType,
@@ -9,12 +10,14 @@ import {
   normalizeContentType,
 } from '../../../constants/content'
 import { formatDateLabel } from '../../../lib/content/date'
+import { getDisplayTitle } from '../../../lib/displayTitle'
 import { useEnrichedContentQuery } from '../../../hooks/queries/useEnrichedContentQuery'
-import type { ContentChildGroup, ContentRelationItem, NestedContent } from '../../../types'
+import type { ContentChildGroup, ContentLink, ContentRelationItem, NestedContent } from '../../../types'
 import type { ContentDisplayProps } from '../../../types/pages'
 import { ContentPageHeader } from '../ContentPageHeader'
-import { asDocumentLink, getDocumentLinks } from './documentUtils'
+import { asDocumentLink, getDocumentLinks, getRelatedLinks } from './documentUtils'
 import { hasVisibleContent } from '../shared/contentTextUtils'
+import { getContentIdFromHref, getUniqueChildLinks } from '../shared/linkUtils'
 import { RichContentHtml } from '../shared/RichContentHtml'
 import {
   buildContentSections,
@@ -116,12 +119,30 @@ function ReferenceDropdown({
   )
 }
 
-type DetailChildSource = ContentRelationItem | NestedContent
+type DetailChildSource = ContentRelationItem | ContentLink | NestedContent
 
 function toDetailChildItem(
   source: DetailChildSource,
   fallbackType?: string,
 ): NestedContent | null {
+  if ('rel' in source) {
+    const id = source.id || getContentIdFromHref(source.href) || ''
+    if (!id) return null
+
+    const title = getDisplayTitle(source, source.title || '')
+
+    return {
+      id,
+      path: source.path || undefined,
+      tittel: title,
+      title,
+      type: source.type || fallbackType,
+      children: source.children
+        ?.map((child) => toDetailChildItem(child))
+        .filter((child): child is NestedContent => Boolean(child)),
+    }
+  }
+
   if (source.is_pdf_only && source.document_url) {
     return null
   }
@@ -131,7 +152,10 @@ function toDetailChildItem(
   const normalizedChildren = source.children
     ?.map((child) => toDetailChildItem(child))
     .filter((child): child is NestedContent => Boolean(child))
-  const title = source.title || ('tittel' in source ? source.tittel : undefined) || ''
+  const title = getDisplayTitle(
+    source,
+    source.title || ('tittel' in source ? source.tittel : undefined) || '',
+  )
   const type =
     ('content_type' in source ? source.content_type : undefined) ||
     ('info_type' in source ? source.info_type : undefined) ||
@@ -181,6 +205,7 @@ export function DetailContentDisplay({
   typeLabelOverride,
   primarySectionTitle = 'Hovedanbefaling',
 }: DetailContentDisplayProps) {
+  const navigate = useNavigate()
   const mobileSectionsNavRef = useRef<HTMLDetailsElement>(null)
   const normalizedType = normalizeContentType(content.content_type)
   const [activeSectionId, setActiveSectionId] = useState<string | null>(null)
@@ -314,6 +339,10 @@ export function DetailContentDisplay({
 
   const childContentItems = useMemo(
     () => {
+      const fallbackLinkItems = dedupeDetailChildItems(
+        getUniqueChildLinks(content.links).map((link) => toDetailChildItem(link)),
+      )
+
       const normalizedReferenceItems = dedupeDetailChildItems(
         (content.references ?? []).map((item) => toDetailChildItem(item, item.content_type || item.info_type)),
       )
@@ -329,21 +358,19 @@ export function DetailContentDisplay({
       )
 
       const groupedItems = getChildItemsFromGroups(content.child_groups, () => true)
+      const combinedItems = dedupeDetailChildItems([
+        ...normalizedReferenceItems,
+        ...normalizedRelatedItems,
+        ...groupedItems,
+      ])
 
-      if (normalizedReferenceItems.length > 0 || normalizedRelatedItems.length > 0) {
-        return dedupeDetailChildItems([
-          ...normalizedReferenceItems,
-          ...normalizedRelatedItems,
-        ])
+      if (combinedItems.length > 0) {
+        return combinedItems
       }
 
-      if (groupedItems.length > 0) {
-        return groupedItems
-      }
-
-      return []
+      return fallbackLinkItems
     },
-    [content.child_groups, content.chapters, content.references, content.related_content],
+    [content.child_groups, content.chapters, content.links, content.references, content.related_content],
   )
   const referenceItems = useMemo(
     () => {
@@ -380,9 +407,12 @@ export function DetailContentDisplay({
     },
     [backendDocumentUrl, content, enrichedContent],
   )
+  const relatedLinks = useMemo(() => getRelatedLinks(content), [content])
   const visibleDocumentLinks = documentLinks
+  const visibleRelatedLinks = relatedLinks
   const hasIntrinsicFallbackContent =
     visibleDocumentLinks.length > 0 ||
+    visibleRelatedLinks.length > 0 ||
     referenceItems.length > 0
   const publicationUrl = useMemo(() => {
     const url = content.url?.trim() || enrichedContent?.url?.trim()
@@ -393,11 +423,34 @@ export function DetailContentDisplay({
     Boolean(publicationUrl) &&
     sections.length === 0 &&
     referenceItems.length === 0 &&
+    visibleRelatedLinks.length === 0 &&
     documentLinks.length === 0
   const hasAnyActionLinks =
     visibleDocumentLinks.length > 0 ||
+    visibleRelatedLinks.length > 0 ||
     shouldShowPublicationFallback
-  const resourceSectionTitle = visibleDocumentLinks.length > 0 ? 'Dokumenter' : 'Lenker'
+  const resourceSectionTitle =
+    visibleDocumentLinks.length > 0 && visibleRelatedLinks.length === 0 ? 'Dokumenter' : 'Lenker'
+
+  const handleRelatedLinkClick = (
+    event: MouseEvent<HTMLAnchorElement>,
+    internalPath?: string,
+  ) => {
+    if (!internalPath) return
+    if (
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.altKey ||
+      event.shiftKey ||
+      event.defaultPrevented
+    ) {
+      return
+    }
+
+    event.preventDefault()
+    navigate(internalPath)
+  }
 
   const hasSidebarContent = sections.length > 1
   const showSidebarLayout = hasSidebarContent
@@ -546,7 +599,7 @@ export function DetailContentDisplay({
             </article>
           ))}
 
-          {!showSidebarLayout && sections.length > 0 && visibleDocumentLinks.length > 0 && (
+          {!showSidebarLayout && sections.length > 0 && (visibleDocumentLinks.length > 0 || visibleRelatedLinks.length > 0) && (
             <section className="space-y-4">
               <Heading level={2} data-size="sm" className="font-title" style={{ marginTop: 0, marginBottom: 0 }}>
                 {resourceSectionTitle}
@@ -563,6 +616,26 @@ export function DetailContentDisplay({
                       <span className="block font-semibold text-slate-900">{document.label}</span>
                       <span className="mt-1 block text-xs text-slate-500">
                         {document.isPdf ? 'PDF' : 'Dokument'}
+                      </span>
+                    </a>
+                  </li>
+                ))}
+                {visibleRelatedLinks.map((link) => (
+                  <li key={`inline-related-${link.href}`}>
+                    <a
+                      href={link.internalPath || link.href}
+                      target={link.internalPath ? undefined : (link.openInNewTab ? '_blank' : undefined)}
+                      rel={link.internalPath ? undefined : (link.openInNewTab ? 'noopener noreferrer' : undefined)}
+                      onClick={(event) => handleRelatedLinkClick(event, link.internalPath)}
+                      className="block rounded-lg border border-slate-200 px-4 py-3 text-sm no-underline transition-colors hover:border-brand/30 hover:bg-slate-50"
+                    >
+                      <span className="block font-semibold text-slate-900">{link.label}</span>
+                      <span className="mt-1 block text-xs text-slate-500">
+                        {link.isPdf
+                          ? 'PDF'
+                          : link.isDocument
+                            ? (link.fileType || 'Dokument')
+                            : 'Rapport eller side'}
                       </span>
                     </a>
                   </li>
@@ -586,7 +659,7 @@ export function DetailContentDisplay({
 
           {sections.length === 0 && referenceItems.length > 0 && <ReferenceDropdown items={referenceItems} />}
 
-          {sections.length === 0 && (visibleDocumentLinks.length > 0 || shouldShowPublicationFallback) && (
+          {sections.length === 0 && (visibleDocumentLinks.length > 0 || visibleRelatedLinks.length > 0 || shouldShowPublicationFallback) && (
             <section className="space-y-4">
               <Heading level={2} data-size="sm" className="font-title" style={{ marginTop: 0, marginBottom: 0 }}>
                 {resourceSectionTitle}
@@ -603,6 +676,26 @@ export function DetailContentDisplay({
                       <span className="block font-semibold text-slate-900">{document.label}</span>
                       <span className="mt-1 block text-xs text-slate-500">
                         {document.isPdf ? 'PDF' : 'Dokument'}
+                      </span>
+                    </a>
+                  </li>
+                ))}
+                {visibleRelatedLinks.map((link) => (
+                  <li key={`fallback-related-${link.href}`}>
+                    <a
+                      href={link.internalPath || link.href}
+                      target={link.internalPath ? undefined : (link.openInNewTab ? '_blank' : undefined)}
+                      rel={link.internalPath ? undefined : (link.openInNewTab ? 'noopener noreferrer' : undefined)}
+                      onClick={(event) => handleRelatedLinkClick(event, link.internalPath)}
+                      className="block rounded-lg border border-slate-200 px-4 py-3 text-sm no-underline transition-colors hover:border-brand/30 hover:bg-slate-50"
+                    >
+                      <span className="block font-semibold text-slate-900">{link.label}</span>
+                      <span className="mt-1 block text-xs text-slate-500">
+                        {link.isPdf
+                          ? 'PDF'
+                          : link.isDocument
+                            ? (link.fileType || 'Dokument')
+                            : 'Rapport eller side'}
                       </span>
                     </a>
                   </li>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Removed the "Explore further" section showing related child items.
  * Removed the separate "Further links" (related links) section; related links now appear directly within the main resource/document area.
  * Resource sidebar now shows documents and related links together; the sidebar title displays "Dokumenter" only when document links exist without related links.
  * Empty-state behavior updated: pages with no text or links now reflect the new logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->